### PR TITLE
splitting scripts

### DIFF
--- a/land.Copernicus Data Download.R
+++ b/land.Copernicus Data Download.R
@@ -80,11 +80,17 @@ download.copernicus.data <- function(path, username, password, timeframe, variab
 
 
 read.copernicus.data <- function(path, timeframe, variable, resolution, version){
-  collection <- paste(variable, version, resolution, sep="_")
-  setwd(PATH)
-  all.filenames.product  <- list.files(pattern=(collection), recursive = T)
+  if(resolution == "300m"){
+    resolution1 <- "333m"
+    variable <- paste0(variable, "300")
+  }else if(resolution == "1km"){
+    resolution1 <- resolution
+  }
+  collection <- paste(variable, version, resolution1, sep="_")
+  setwd(path)
+  all.filenames.product  <- list.files(pattern=(collection), recursive = TRUE)
   datepattern   <- gsub("-", "", timeframe)
   datepattern.in.timeframe <- names(unlist(sapply(datepattern, grep, all.filenames.product)))
-  filenames.in.timeframe <- paste(PATH, all.filenames.product[unlist(sapply(datepattern, grep, all.filenames.product))], sep="/")
+  filenames.in.timeframe <- paste(path, all.filenames.product[unlist(sapply(datepattern, grep, all.filenames.product))], sep="/")
   data <- stack(filenames.in.timeframe)  
 }

--- a/land.Copernicus Data Download.R
+++ b/land.Copernicus Data Download.R
@@ -43,19 +43,27 @@ if(require(raster) == FALSE){install.packages("raster", repos = "https://cloud.r
 
 download.copernicus.data <- function(path, username, password, timeframe, variable, resolution, version){
   
-  collection <- paste(variable, version, resolution, sep="_")
+  if(resolution == "300m"){
+    resolution1 <- "333m"
+    variable <- paste0(variable, "300")
+  }else if(resolution == "1km"){
+    resolution1 <- resolution
+  }
+  
+  collection <- paste(variable, version, resolution1, sep="_")
   
   product.link<- paste0("@land.copernicus.vgt.vito.be/manifest/", collection, "/manifest_cgls_", collection, "_latest.txt" )
-
+  
   url <- paste0("https://", paste(username, password, sep=":"), product.link)
-  if (length(url)==0) {print("This product is not available or the product name is misspecified")}
-
+  #if (length(url)==0) {print("This product is not available or the product name is misspecified")}
+  
   file.url <- getURL(url, ftp.use.epsv = FALSE, dirlistonly = TRUE, crlf = TRUE)
   file.url <- unlist(strsplit(file.url, "\n"))
   file.url <- paste0("https://", paste(username, password, sep=":"), "@", sub(".*//", "",file.url))
-
+  if(grepl("does not exist", file.url[10])) stop("This product is not available or the product name is misspecified")
+  
   setwd(path)
-  dir.create(collection)
+  if(!dir.exists(collection)) dir.create(collection)
   setwd(paste(path, collection, sep="/"))
   
   for (i in 1:length(timeframe)){
@@ -67,8 +75,6 @@ download.copernicus.data <- function(path, username, password, timeframe, variab
     }
   }
 }  
-
-
 
 
 

--- a/land.Copernicus Data Download.R
+++ b/land.Copernicus Data Download.R
@@ -19,30 +19,26 @@
 #
 #
 #First version: 28.10.2019
-#Last update  : 05.11.2019
+#Last update  : 08.06.2020
 #
 ###########################################################################################################################
 
-#install.packages("RCurl")
-#install.packages("ncdf4")
-#install.packages("raster")
 
-library(RCurl)
-library(ncdf4)
-library(raster)
-rm(list=ls())
+if(require(RCurl) == FALSE){install.packages("RCurl", repos = "https://cloud.r-project.org"); library(RCurl)} else {library(RCurl)}
+if(require(ncdf4) == FALSE){install.packages("ncdf4", repos = "https://cloud.r-project.org"); library(ncdf4)} else {library(ncdf4)}
+if(require(raster) == FALSE){install.packages("raster", repos = "https://cloud.r-project.org"); library(raster)} else {library(raster)}
+#rm(list=ls())
 
-#SET TARGET DIRECTORY USERNAME, PASSWORD, TIMEFRAME OF YOUR INTEREST AND PRODUCT (constising of a variable, resolution and version). 
 #Check https://land.copernicus.eu/global/products/ for a product overview and product details
 #check https://land.copernicus.vgt.vito.be/manifest/ for an overview for data availability in the manifest 
 
-PATH       <- "" #INSERT TARGET DIRECTORY, for example: D:/land.copernicus
-USERNAME   <- "" #INSERT USERNAME
-PASSWORD   <- "" #INSERT PASSWORD
-TIMEFRAME  <- seq(as.Date("2019-06-01"), as.Date("2019-06-15"), by="days") #INSERT TIMEFRAME OF INTEREST, for example June 2019
-VARIABLE   <- "ssm" #INSERT PRODUCT VARIABLE;(for example fapar) -> CHOSE FROM fapar, fcover, lai, ndvi,  ssm, swi, lst, ...
-RESOLUTION <- "1km" #INSERT RESOLTION (1km, 300m or 100m)
-VERSION    <- "v1" #"INSERT VERSION: "v1", "v2", "v3",... 
+#PATH       : TARGET DIRECTORY, for example: D:/land.copernicus
+#USERNAME   : USERNAME
+#PASSWORD   : PASSWORD
+#TIMEFRAME  : TIMEFRAME OF INTEREST, for example June 2019
+#VARIABLE   : PRODUCT VARIABLE; CHOSE FROM fapar, fcover, lai, ndvi, ssm, swi, lst...
+#RESOLUTION : RESOLTION; CHOSE FROM  1km, 300m or 100m
+#VERSION    : VERSION; CHOSE FROM "v1", "v2", "v3"... 
 
 
 download.copernicus.data <- function(path, username, password, timeframe, variable, resolution, version){
@@ -72,17 +68,9 @@ download.copernicus.data <- function(path, username, password, timeframe, variab
   }
 }  
 
-download.copernicus.data(path=PATH, username=USERNAME, password=PASSWORD, timeframe=TIMEFRAME, variable=VARIABLE, resolution=RESOLUTION, version=VERSION)
 
 
-####Open the downloaded data in R### 
-#SELECT THE DATA YOU WANT TO OPEN (data has to be downloaded first)
 
-PATH       <- "D:/land.copernicus" #INSERT DIRECTORY, for example: D:/land.copernicus
-TIMEFRAME  <- seq(as.Date("2019-06-01"), as.Date("2019-06-15"), by="days") #INSERT TIMEFRAME OF INTEREST, for example June 2019
-VARIABLE   <- "ssm" #INSERT PRODUCT VARIABLE;(for example fapar) -> CHOSE FROM fapar, fcover, lai, ndvi,  ss, swi, lst, ...
-RESOLUTION <- "1km" #INSERT RESOLTION (1km, 300m or 100m)
-VERSION    <- "v1" #"INSERT VERSION: "v1", "v2", "v3",... 
 
 
 read.copernicus.data <- function(path, timeframe, variable, resolution, version){
@@ -94,8 +82,3 @@ read.copernicus.data <- function(path, timeframe, variable, resolution, version)
   filenames.in.timeframe <- paste(PATH, all.filenames.product[unlist(sapply(datepattern, grep, all.filenames.product))], sep="/")
   data <- stack(filenames.in.timeframe)  
 }
-
-data <- read.copernicus.data(path=PATH,timeframe=TIMEFRAME, variable=VARIABLE, resolution=RESOLUTION, version=VERSION)
-
-#view first layer of the data
-plot(data[[1]])

--- a/land.CopernicusDataDownload_example.R
+++ b/land.CopernicusDataDownload_example.R
@@ -1,0 +1,67 @@
+############################################################################################################################
+#
+#COPERNICUS DATA DOWNLOAD AND READ: EXAMPLE
+#
+#This is an example on how to run the functions found in 'land.Copernicus Data Download.R'
+#
+#These functions allow to automatically download data provided by the Copernicus Global Land Service and open this data as rasterstack in R.
+#See: https://land.copernicus.eu/global/
+#
+#These functions rely on the data provided in the data manifest of the Copernicus service.
+#These functinos allow to download the data without ordering products first,
+#but you need to register at https://land.copernicus.eu/global/ and create a username and password. 
+#
+#Set your path, username, password, timeframe, variable, resolution and if more than 1 version exists, version number. New products are created regularly.
+#
+#These functions are distributed in the hope that they will be useful,
+#but without any warranty.
+#
+#Author: Willemijn Vroege, ETH Zürich with support of Tim Jacobs, VITO, Copernicus Global Help Desk
+#E-mail: wvroege@ethz.ch
+#
+#
+#First version: 28.10.2019
+#Last update  : 08.06.2020
+#
+###########################################################################################################################
+
+
+## Reading Functions ####
+if(require(devtools) == FALSE){install.packages("devtools", repos = "https://cloud.r-project.org"); library(devtools)} else {library(devtools)}
+source_url("https://github.com/xavi-rp/Copernicus-Global-Land-Service-Data-Download-with-R/blob/master/land.Copernicus%20Data%20Download.R?raw=TRUE")
+
+
+## Downloading Data ####
+#SET TARGET DIRECTORY USERNAME, PASSWORD, TIMEFRAME OF YOUR INTEREST AND PRODUCT (constising of a variable, resolution and version). 
+#Check https://land.copernicus.eu/global/products/ for a product overview and product details
+#check https://land.copernicus.vgt.vito.be/manifest/ for an overview for data availability in the manifest 
+
+PATH       <- "" #INSERT TARGET DIRECTORY, for example: D:/land.copernicus
+USERNAME   <- "" #INSERT USERNAME
+PASSWORD   <- "" #INSERT PASSWORD
+TIMEFRAME  <- seq(as.Date("2019-06-01"), as.Date("2019-06-15"), by="days") #INSERT TIMEFRAME OF INTEREST, for example June 2019
+VARIABLE   <- "ssm" #INSERT PRODUCT VARIABLE;(for example fapar) -> CHOSE FROM fapar, fcover, lai, ndvi,  ssm, swi, lst, ...
+RESOLUTION <- "1km" #INSERT RESOLTION (1km, 300m or 100m)
+VERSION    <- "v1" #"INSERT VERSION: "v1", "v2", "v3",... 
+
+
+download.copernicus.data(path=PATH, username=USERNAME, password=PASSWORD, timeframe=TIMEFRAME, variable=VARIABLE, resolution=RESOLUTION, version=VERSION)
+
+
+
+
+
+## Reading Data ####
+#SET TARGET DIRECTORY, TIMEFRAME OF YOUR INTEREST AND PRODUCT (constising of a variable, resolution and version). 
+
+PATH       <- "D:/land.copernicus" #INSERT DIRECTORY, for example: D:/land.copernicus
+TIMEFRAME  <- seq(as.Date("2019-06-01"), as.Date("2019-06-15"), by="days") #INSERT TIMEFRAME OF INTEREST, for example June 2019
+VARIABLE   <- "ssm" #INSERT PRODUCT VARIABLE;(for example fapar) -> CHOSE FROM fapar, fcover, lai, ndvi,  ss, swi, lst, ...
+RESOLUTION <- "1km" #INSERT RESOLTION (1km, 300m or 100m)
+VERSION    <- "v1" #"INSERT VERSION: "v1", "v2", "v3",... 
+
+
+data <- read.copernicus.data(path=PATH,timeframe=TIMEFRAME, variable=VARIABLE, resolution=RESOLUTION, version=VERSION)
+
+#view first layer of the data
+plot(data[[1]])


### PR DESCRIPTION
- I propose splitting the script into two: one for the functions and another for the example. Doing so, the functions can be directly sourced from GitHub in any R session.
- As the URLs of the different products/resolution have no exactly the same structure (see https://land.copernicus.vgt.vito.be/manifest/), I've included an if-statement to work with all products. Checked for NDVI_1km_v2, NDVI_300m_v1, FAPAR_1km_v1, FAPAR_300m_v1 and LAI_300m_v1.
- Other minimal bugs and changes here and there